### PR TITLE
rename Utility to ObjectPath

### DIFF
--- a/specs/object-path/object-path.spec.php
+++ b/specs/object-path/object-path.spec.php
@@ -1,5 +1,5 @@
 <?php
-use Peridot\Leo\Utility\ObjectPath;
+use Peridot\Leo\ObjectPath\ObjectPath;
 
 describe('ObjectPath', function() {
 

--- a/src/Matcher/PropertyMatcher.php
+++ b/src/Matcher/PropertyMatcher.php
@@ -3,8 +3,8 @@ namespace Peridot\Leo\Matcher;
 
 use Peridot\Leo\Matcher\Template\ArrayTemplate;
 use Peridot\Leo\Matcher\Template\TemplateInterface;
-use Peridot\Leo\Utility\ObjectPath;
-use Peridot\Leo\Utility\ObjectPathValue;
+use Peridot\Leo\ObjectPath\ObjectPath;
+use Peridot\Leo\ObjectPath\ObjectPathValue;
 
 /**
  * PropertyMatcher determines if the actual array or object has the expected property, and optionally matches

--- a/src/ObjectPath/ObjectPath.php
+++ b/src/ObjectPath/ObjectPath.php
@@ -1,5 +1,5 @@
 <?php
-namespace Peridot\Leo\Utility;
+namespace Peridot\Leo\ObjectPath;
 
 /**
  * ObjectPath is a utility for parsing object and array strings into

--- a/src/ObjectPath/ObjectPathValue.php
+++ b/src/ObjectPath/ObjectPathValue.php
@@ -1,5 +1,5 @@
 <?php
-namespace Peridot\Leo\Utility;
+namespace Peridot\Leo\ObjectPath;
 
 /**
  * An ObjectPathValue is the result of parsing a path expression via ObjectPath.


### PR DESCRIPTION
The Utility namespace is not really indicative of what it's responsibility is. Updated to reflect responsibility more accurately.
