### PR TITLE
array_search should be strict in InclusionMatcher

### DIFF
--- a/specs/matcher/inclusion-matcher.spec.php
+++ b/specs/matcher/inclusion-matcher.spec.php
@@ -32,6 +32,12 @@ describe('InclusionMatcher', function() {
         expect($match->isMatch())->to->equal(false);
     });
 
+    it('should return false if types are different', function() {
+        $matcher = new InclusionMatcher('1');
+        $match = $matcher->match([1]);
+        expect($match->isMatch())->to->equal(false);
+    });
+
     it('should return true if value is not in an instance of ArrayAccess', function() {
         $match = $this->matcher->match(new ArrayObject(['B', 'C', 'D']));
         expect($match->isMatch())->to->equal(true);

--- a/src/Matcher/InclusionMatcher.php
+++ b/src/Matcher/InclusionMatcher.php
@@ -24,7 +24,7 @@ class InclusionMatcher extends AbstractMatcher
     protected function doMatch($actual)
     {
         if (is_array($actual) or $actual instanceof ArrayAccess) {
-            return array_search($this->expected, $actual) !== false;
+            return array_search($this->expected, $actual, true) !== false;
         }
 
         if (is_string($actual)) {


### PR DESCRIPTION
`array_search` should be strict. 

This bit me in `peridot-concurrency` when testing serialized/unserialized messages. searching for '1' should not match element 1.