### PR TITLE
add debug flag to peridot.php and clean up warnings

### DIFF
--- a/peridot.php
+++ b/peridot.php
@@ -24,5 +24,13 @@ return function(EventEmitterInterface $emitter) {
     });
 
     $prophecy = new ProphecyPlugin($emitter);
+
+    $debug = getenv('DEBUG');
+
+    if ($debug) {
+        $emitter->on('error', function ($number, $message, $file, $line) {
+            print "Error: $number - $message:$file:$line\n";
+        });
+    }
 };
 

--- a/src/Core/Definitions.php
+++ b/src/Core/Definitions.php
@@ -76,7 +76,7 @@ return function (Assertion $assertion) {
         ->addMethod('a', $type)
         ->addMethod('an', $type);
 
-    $include = function ($expected, $message) {
+    $include = function ($expected, $message = "") {
         $this->flag('message', $message);
         return new InclusionMatcher($expected);
     };

--- a/src/DynamicObjectTrait.php
+++ b/src/DynamicObjectTrait.php
@@ -53,17 +53,21 @@ trait DynamicObjectTrait
      * A simple mechanism for storing arbitrary flags. Flags are useful
      * for tweaking behavior based on their presence.
      *
-     * @return $this
+     * @return $this|mixed
      */
     public function flag()
     {
         $args = func_get_args();
         $num = count($args);
+
         if ($num > 1) {
             $this->flags[$args[0]] = $args[1];
             return $this;
         }
-        return $this->flags[$args[0]];
+
+        if (array_key_exists($args[0], $this->flags)) {
+            return $this->flags[$args[0]];
+        }
     }
 
     /**

--- a/src/Matcher/AbstractMatcher.php
+++ b/src/Matcher/AbstractMatcher.php
@@ -66,7 +66,7 @@ abstract class AbstractMatcher implements MatcherInterface
      * @param mixed $actual
      * @return Match
      */
-    public function match($actual)
+    public function match($actual = "")
     {
         $isMatch = $this->doMatch($actual);
         if ($this->isNegated()) {

--- a/src/Matcher/InclusionMatcher.php
+++ b/src/Matcher/InclusionMatcher.php
@@ -23,6 +23,7 @@ class InclusionMatcher extends AbstractMatcher
      */
     protected function doMatch($actual)
     {
+        //we will support ArrayAccess for now, even though array_search throws a warning about it
         if (is_array($actual) or $actual instanceof ArrayAccess) {
             return array_search($this->expected, $actual, true) !== false;
         }

--- a/src/Matcher/Template/ArrayTemplate.php
+++ b/src/Matcher/Template/ArrayTemplate.php
@@ -19,12 +19,12 @@ class ArrayTemplate implements TemplateInterface
     /**
      * @var string
      */
-    protected $default;
+    protected $default = '';
 
     /**
      * @var string
      */
-    protected $negated;
+    protected $negated = '';
 
     /**
      * @var array
@@ -36,8 +36,13 @@ class ArrayTemplate implements TemplateInterface
      */
     public function __construct(array $templates)
     {
-        $this->default = $templates['default'];
-        $this->negated = $templates['negated'];
+        if (array_key_exists('default', $templates)) {
+            $this->default = $templates['default'];
+        }
+
+        if (array_key_exists('negated', $templates)) {
+            $this->negated = $templates['negated'];
+        }
     }
 
     /**

--- a/src/ObjectPath/ObjectPath.php
+++ b/src/ObjectPath/ObjectPath.php
@@ -63,6 +63,11 @@ class ObjectPath
             $key = array_shift($parts);
             $key = $this->normalizeKey($key);
             $pathValue = array_key_exists($key, $properties) ? new ObjectPathValue($key, $properties[$key]) : null;
+
+            if (! array_key_exists($key, $properties)) {
+                break;
+            }
+
             $properties = $this->getPropertyCollection($properties[$key]);
         }
         return $pathValue;
@@ -93,11 +98,11 @@ class ObjectPath
      */
     protected function getPropertyCollection($subject)
     {
-        if (is_array($subject)) {
-            return $subject;
+        if (is_object($subject)) {
+            return get_object_vars($subject);
         }
 
-        return get_object_vars($subject);
+        return $subject;
     }
 
     /**


### PR DESCRIPTION
Added a `DEBUG` flag to the peridot.php file to catch any errant PHP warnings. 

Noticed quite a few so I cleaned them all up in this PR - with the exception of warnings thrown by `array_search` when matching against `ArrayAccess`. Seems silly that PHP allows it, but cries about it.