### PR TITLE
Fixed backwards assertion message templates.

### DIFF
--- a/specs/interfaces/assert.spec.php
+++ b/specs/interfaces/assert.spec.php
@@ -152,7 +152,7 @@ describe('assert', function() {
         it('should throw an exception if actual value is not identical to expected value', function() {
             $this->assert->throws(function() {
                 $this->assert->strictEqual("string", "other");
-            }, 'Exception', 'Expected "other" to be identical to "string"');
+            }, 'Exception', 'Expected "string" to be identical to "other"');
         });
 
         it('allow a user message', function() {

--- a/specs/matcher/exception-matcher.spec.php
+++ b/specs/matcher/exception-matcher.spec.php
@@ -94,7 +94,7 @@ describe('ExceptionMatcher', function() {
             $default = $template->getDefaultTemplate();
             $negated = $template->getNegatedTemplate();
             expect($default)->to->equal('Expected exception message {{expected}}, got {{actual}}');
-            expect($negated)->to->equal('Expected exception message {{expected}} not to equal {{actual}}');
+            expect($negated)->to->equal('Expected exception message {{actual}} not to equal {{expected}}');
         });
     });
 

--- a/src/Matcher/EqualMatcher.php
+++ b/src/Matcher/EqualMatcher.php
@@ -33,7 +33,7 @@ class EqualMatcher extends AbstractMatcher
     {
         return new ArrayTemplate([
             'default' => 'Expected {{expected}}, got {{actual}}',
-            'negated' => 'Expected {{expected}} not to equal {{actual}}'
+            'negated' => 'Expected {{actual}} not to equal {{expected}}'
         ]);
     }
 }

--- a/src/Matcher/ExceptionMatcher.php
+++ b/src/Matcher/ExceptionMatcher.php
@@ -172,7 +172,7 @@ class ExceptionMatcher extends AbstractMatcher
     {
         return new ArrayTemplate([
             'default' => 'Expected exception message {{expected}}, got {{actual}}',
-            'negated' => 'Expected exception message {{expected}} not to equal {{actual}}'
+            'negated' => 'Expected exception message {{actual}} not to equal {{expected}}'
         ]);
     }
 

--- a/src/Matcher/SameMatcher.php
+++ b/src/Matcher/SameMatcher.php
@@ -30,8 +30,8 @@ class SameMatcher extends AbstractMatcher
     public function getDefaultTemplate()
     {
         return new ArrayTemplate([
-            'default' => 'Expected {{expected}} to be identical to {{actual}}',
-            'negated' => 'Expected {{expected}} not to be identical to {{actual}}'
+            'default' => 'Expected {{actual}} to be identical to {{expected}}',
+            'negated' => 'Expected {{actual}} not to be identical to {{expected}}'
         ]);
     }
 }


### PR DESCRIPTION
This PR fixes some assertion failure messages that are currently back-to-front. Most notably for me:

```php
expect('a')->to->equal('b');
```

Which should produce:

> Expected "a" to be identical to "b"

But currently results in:

> Expected "b" to be identical to "a"