### PR TITLE
Trim internal lines from assertion exception stack traces.

### DIFF
--- a/specs/responder/exception/assertion-exception.spec.php
+++ b/specs/responder/exception/assertion-exception.spec.php
@@ -1,0 +1,102 @@
+<?php
+
+use Exception;
+use Peridot\Leo\Responder\Exception\AssertionException;
+
+describe('AssertionException', function() {
+    describe('::trim()', function() {
+        it('handles traces without a Leo call', function() {
+            $exception = new Exception();
+            AssertionException::trim($exception);
+            expect(count($exception->getTrace()))->to->equal(0);
+        });
+    });
+
+    describe('::traceLeoCall()', function() {
+        it('handles method call traces', function() {
+            $trace = [
+                [
+                    'file' => '/path/to/file/a',
+                    'line' => 111,
+                    'function' => 'methodA',
+                    'class' =>  'Peridot\Leo\ClassA',
+                ],
+                [
+                    'file' => '/path/to/file/b',
+                    'line' => 222,
+                    'function' => 'methodB',
+                    'class' =>  'Peridot\Leo\ClassB',
+                ],
+                [
+                    'file' => '/path/to/file/c',
+                    'line' => 333,
+                    'function' => 'methodC',
+                    'class' => 'ClassC',
+                ],
+            ];
+            $expected = [
+                'file' => '/path/to/file/b',
+                'line' => 222,
+                'function' => 'methodB',
+                'class' =>  'Peridot\Leo\ClassB',
+            ];
+
+            expect(AssertionException::traceLeoCall($trace))->to->equal($expected);
+        });
+
+        it('handles function call traces', function() {
+            $trace = [
+                [
+                    'file' => '/path/to/file/a',
+                    'line' => 111,
+                    'function' => 'methodA',
+                    'class' =>  'Peridot\Leo\ClassA',
+                ],
+                [
+                    'file' => '/path/to/file/b',
+                    'line' => 222,
+                    'function' => 'Peridot\Leo\functionB',
+                ],
+                [
+                    'file' => '/path/to/file/c',
+                    'line' => 333,
+                    'function' => 'functionC',
+                ],
+            ];
+            $expected = [
+                'file' => '/path/to/file/b',
+                'line' => 222,
+                'function' => 'Peridot\Leo\functionB',
+            ];
+
+            expect(AssertionException::traceLeoCall($trace))->to->equal($expected);
+        });
+
+        it('handles traces with no external calls', function() {
+            $trace = [
+                [
+                    'file' => '/path/to/file/a',
+                    'line' => 111,
+                    'function' => 'methodA',
+                    'class' =>  'Peridot\Leo\ClassA',
+                ],
+                [
+                    'file' => '/path/to/file/b',
+                    'line' => 222,
+                    'function' => 'Peridot\Leo\functionB',
+                ],
+            ];
+            $expected = [
+                'file' => '/path/to/file/b',
+                'line' => 222,
+                'function' => 'Peridot\Leo\functionB',
+            ];
+
+            expect(AssertionException::traceLeoCall($trace))->to->equal($expected);
+        });
+
+        it('handles empty traces', function() {
+            expect(AssertionException::traceLeoCall([]))->to->equal(null);
+        });
+    });
+});

--- a/specs/responder/responder.spec.php
+++ b/specs/responder/responder.spec.php
@@ -2,6 +2,7 @@
 use Peridot\Leo\Matcher\Match;
 use Peridot\Leo\Matcher\Template\ArrayTemplate;
 use Peridot\Leo\Responder\ExceptionResponder;
+use Peridot\Leo\Responder\Exception\AssertionException;
 use Prophecy\Argument;
 
 describe('ExceptionResponder', function() {
@@ -26,12 +27,30 @@ describe('ExceptionResponder', function() {
 
         it('should respond to a false match by throwing an exception', function() {
             $this->formatter->setMatch($this->match)->shouldBeCalled();
-            expect([$this->responder, 'respond'])->with($this->match, $this->template)->to->throw('Exception', 'FAIL');
+            expect([$this->responder, 'respond'])->with($this->match, $this->template)
+                ->to->throw('Peridot\Leo\Responder\Exception\AssertionException', 'FAIL');
         });
 
         it('should allow a user exception message', function() {
             $this->formatter->setMatch($this->match)->shouldBeCalled();
-            expect([$this->responder, 'respond'])->with($this->match, $this->template, "user")->to->throw('Exception', 'user');
+            expect([$this->responder, 'respond'])->with($this->match, $this->template, "user")
+                ->to->throw('Peridot\Leo\Responder\Exception\AssertionException', 'user');
+        });
+
+        it('should trim the exception stack trace', function() {
+            $this->formatter->setMatch($this->match)->shouldBeCalled();
+            $line = null;
+            $exception = null;
+            $trace = [];
+            try {
+                ($line = __LINE__) && $this->responder->respond($this->match, $this->template);
+            } catch (AssertionException $exception) {
+                $trace = $exception->getTrace();
+            }
+            expect($exception)->to->be->an->instanceof('Peridot\Leo\Responder\Exception\AssertionException');
+            expect(count($trace))->to->equal(1);
+            expect($trace[0]['file'])->to->equal(__FILE__);
+            expect($trace[0]['line'])->to->equal($line);
         });
 
         it('should do nothing for a true match', function() {

--- a/src/Responder/Exception/AssertionException.php
+++ b/src/Responder/Exception/AssertionException.php
@@ -1,0 +1,102 @@
+<?php
+namespace Peridot\Leo\Responder\Exception;
+
+use Exception;
+use ReflectionClass;
+
+/**
+ * Thrown by ExceptionResponder when an assertion fails.
+ *
+ * @package Peridot\Leo\Responder\Exception
+ */
+final class AssertionException extends Exception
+{
+    /**
+     * Trim the supplied exception's stack trace to only include relevant
+     * information.
+     *
+     * Also replaces the file path and line number.
+     *
+     * @param Exception $exception The exception.
+     */
+    public static function trim(Exception $exception)
+    {
+        $reflector = new ReflectionClass('Exception');
+
+        $traceProperty = $reflector->getProperty('trace');
+        $traceProperty->setAccessible(true);
+        $fileProperty = $reflector->getProperty('file');
+        $fileProperty->setAccessible(true);
+        $lineProperty = $reflector->getProperty('line');
+        $lineProperty->setAccessible(true);
+
+        $call = static::traceLeoCall($traceProperty->getValue($exception));
+
+        if ($call) {
+            $traceProperty->setValue($exception, array($call));
+            $fileProperty->setValue(
+                $exception,
+                isset($call['file']) ? $call['file'] : null
+            );
+            $lineProperty->setValue(
+                $exception,
+                isset($call['line']) ? $call['line'] : null
+            );
+        } else {
+            $traceProperty->setValue($exception, array());
+            $fileProperty->setValue($exception, null);
+            $lineProperty->setValue($exception, null);
+        }
+    }
+
+    /**
+     * Find the Leo entry point call in a stack trace.
+     *
+     * @param array $trace The stack trace.
+     *
+     * @return array|null The call, or null if unable to determine the entry point.
+     */
+    public static function traceLeoCall(array $trace)
+    {
+        $prefix = 'Peridot\\Leo\\';
+
+        $index = null;
+        $broke = false;
+
+        foreach ($trace as $index => $call) {
+            if (isset($call['class'])) {
+                if (0 !== strpos($call['class'], $prefix)) {
+                    $broke = true;
+
+                    break;
+                }
+            } elseif (0 !== strpos($call['function'], $prefix)) {
+                $broke = true;
+
+                break;
+            }
+        }
+
+        if (null === $index) {
+            return;
+        }
+
+        if (!$broke) {
+            ++$index;
+        }
+
+        return $trace[$index - 1];
+    }
+
+    /**
+     * Construct a new assertion exception.
+     *
+     * @param string $message The message.
+     */
+    public function __construct($message)
+    {
+        parent::__construct($message);
+
+        static::trim($this);
+    }
+}

--- a/src/Responder/ExceptionResponder.php
+++ b/src/Responder/ExceptionResponder.php
@@ -5,6 +5,7 @@ use Exception;
 use Peridot\Leo\Formatter\FormatterInterface;
 use Peridot\Leo\Matcher\Match;
 use Peridot\Leo\Matcher\Template\TemplateInterface;
+use Peridot\Leo\Responder\Exception\AssertionException;
 
 /**
  * The ExceptionResponder responds to a match by throwing an exception
@@ -46,6 +47,6 @@ class ExceptionResponder implements ResponderInterface
 
         $this->formatter->setMatch($match);
         $message = ($message) ? $message : $this->formatter->getMessage($template);
-        throw new Exception($message);
+        throw new AssertionException($message);
     }
 }


### PR DESCRIPTION
This PR significantly improves the output from failed assertions. The code is borrowed from [Phony](https://github.com/eloquent/phony), which has similar code in its [AssertionException](https://github.com/eloquent/phony/blob/72a594f/src/Assertion/Exception/AssertionException.php).

To summarize, a failed assertion in Leo currently produces a large amount of output, dominated by stack trace data, most of which details vendor code of no interest to the user. This obfuscates the important information, i.e. where the failing assertion was made.

Consider the following Peridot test, utilizing Leo:

```php
<?php

describe('a', function () {
    it('should fail', function () {
        expect('a')->to->equal('b'); // note that this is line no. 5
    });
});
```

Currently the failing assertion generates this output:

```shell
  1) a should fail:
     Expected "b" to be identical to "a"
      #0 /path/to/leo/src/Assertion.php(224): Peridot\Leo\Responder\ExceptionResponder->respond(Object(Peridot\Leo\Matcher\Match), Object(Peridot\Leo\Matcher\Template\ArrayTemplate), 'Expected "b" to...')
      #1 /path/to/leo/src/Assertion.php(156): Peridot\Leo\Assertion->assert(Object(Peridot\Leo\Matcher\SameMatcher))
      #2 /path/to/leo/src/Assertion.php(117): Peridot\Leo\Assertion->request(Object(Closure), Array)
      #3 /path/to/tmp/a.spec.php(5): Peridot\Leo\Assertion->__call('equal', Array)
      #4 [internal function]: Peridot\Core\Scope->{closure}()
      #5 /path/to/peridot/src/Core/Test.php(57): call_user_func_array(Object(Closure), Array)
      #6 /path/to/peridot/src/Core/Test.php(43): Peridot\Core\Test->executeTest(Object(Peridot\Core\TestResult))
      #7 /path/to/peridot/src/Core/Suite.php(112): Peridot\Core\Test->run(Object(Peridot\Core\TestResult))
      #8 /path/to/peridot/src/Core/Suite.php(83): Peridot\Core\Suite->runTest(Object(Peridot\Core\Test), Object(Peridot\Core\TestResult))
      #9 /path/to/peridot/src/Core/Suite.php(112): Peridot\Core\Suite->run(Object(Peridot\Core\TestResult))
      #10 /path/to/peridot/src/Core/Suite.php(83): Peridot\Core\Suite->runTest(Object(Peridot\Core\Suite), Object(Peridot\Core\TestResult))
      #11 /path/to/peridot/src/Runner/Runner.php(59): Peridot\Core\Suite->run(Object(Peridot\Core\TestResult))
      #12 /path/to/peridot/src/Console/Command.php(176): Peridot\Runner\Runner->run(Object(Peridot\Core\TestResult))
      #13 /path/to/peridot/src/Console/Command.php(149): Peridot\Console\Command->getResult()
      #14 /path/to/vendor/symfony/console/Command/Command.php(259): Peridot\Console\Command->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
      #15 /path/to/vendor/symfony/console/Application.php(844): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
      #16 /path/to/vendor/symfony/console/Application.php(192): Symfony\Component\Console\Application->doRunCommand(Object(Peridot\Console\Command), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
      #17 /path/to/peridot/src/Console/Application.php(84): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
      #18 /path/to/vendor/symfony/console/Application.php(123): Peridot\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
      #19 /path/to/peridot/src/Console/Application.php(63): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
      #20 /path/to/peridot/bin/peridot(45): Peridot\Console\Application->run()
      #21 {main}
```

After applying this PR, the same assertion results in this output:

```shell
  1) a should fail:
     Expected "b" to be identical to "a"
      #0 /path/to/tmp/a.spec.php(5): Peridot\Leo\Assertion->__call('equal', Array)
      #1 {main}
```

Notice that the file and line information now point to exactly where the failing assertion was made.