### PR TITLE
Support PHP 7 `Throwable` and add PHP 7 to Travis CI build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs
 css
 img
 build
+/code-coverage-report

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.6
   - 5.5
   - 5.4
+  - 7.0
 
 install:
   - composer install --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "files":["src/Interfaces/_interface.bdd.php"]
     },
     "require-dev": {
+        "dstuecken/php7ify": "^1.1",
         "peridot-php/peridot-jumpstart": "~1.0",
         "peridot-php/peridot-prophecy-plugin": "~1.0",
         "satooshi/php-coveralls": "~0.6"

--- a/specs/matcher/exception-matcher.spec.php
+++ b/specs/matcher/exception-matcher.spec.php
@@ -86,6 +86,26 @@ describe('ExceptionMatcher', function() {
                 });
             });
         });
+
+        context('with throwable', function () {
+            beforeEach(function () {
+                $this->matcher = new ExceptionMatcher('TypeError');
+            });
+
+            it('should return true result if callable throws throwable', function() {
+                $result = $this->matcher->match(function() {
+                    throw new TypeError('hello world');
+                });
+                expect($result->isMatch())->to->equal(true);
+            });
+
+            it('should return false result if callable throws different type', function() {
+                $result = $this->matcher->match(function() {
+                    throw new ParseError('hello world');
+                });
+                expect($result->isMatch())->to->equal(false);
+            });
+        });
     });
 
     describe('->getDefaultMessageTemplate()', function() {

--- a/specs/responder/exception/assertion-exception.spec.php
+++ b/specs/responder/exception/assertion-exception.spec.php
@@ -1,6 +1,5 @@
 <?php
 
-use Exception;
 use Peridot\Leo\Responder\Exception\AssertionException;
 
 describe('AssertionException', function() {

--- a/src/Matcher/ExceptionMatcher.php
+++ b/src/Matcher/ExceptionMatcher.php
@@ -206,16 +206,18 @@ class ExceptionMatcher extends AbstractMatcher
             call_user_func_array($actual, $this->arguments);
             return false;
         } catch (\Exception $e) {
-            $message = $e->getMessage();
-            if ($this->expectedMessage) {
-                $this->setMessage($message);
-                return $this->expectedMessage == $message;
-            }
-            if (!$e instanceof $this->expected) {
-                return false;
-            }
+            // fall-through ...
+        } catch (\Throwable $e) {
+            // fall-through ...
         }
-        return true;
+
+        $message = $e->getMessage();
+        if ($this->expectedMessage) {
+            $this->setMessage($message);
+            return $this->expectedMessage == $message;
+        }
+
+        return $e instanceof $this->expected;
     }
 
     /**


### PR DESCRIPTION
This PR adds support for PHP 7 error exceptions to `expect($fn)->throw($e)` by catching `Throwable` in `ExceptionMatcher`.  To allow testing under PHP 5 I've included a [PHP 7 polyfill](github.com/dstuecken/php7ify) as a development dependency only. 