### PR TITLE
Fixed simultaneous assertion of exception type and message. Closes #20.

### DIFF
--- a/specs/interfaces/assert.spec.php
+++ b/specs/interfaces/assert.spec.php
@@ -79,7 +79,7 @@ describe('assert', function() {
             $this->assert->throws(function() {
                 $this->assert->doesNotThrow(function() {
                     throw new Exception('failure');
-                }, 'RuntimeException', 'failure');
+                }, 'Exception', 'failure');
             }, 'Exception');
         });
 
@@ -87,7 +87,7 @@ describe('assert', function() {
             $this->assert->throws(function() {
                 $this->assert->doesNotThrow(function() {
                     throw new Exception('failure');
-                }, 'RuntimeException', 'failure', 'oooooops');
+                }, 'Exception', 'failure', 'oooooops');
             }, 'Exception', 'oooooops');
         });
     });

--- a/specs/matcher/exception-matcher.spec.php
+++ b/specs/matcher/exception-matcher.spec.php
@@ -68,6 +68,14 @@ describe('ExceptionMatcher', function() {
                 expect($result->isMatch())->to->equal(false);
             });
 
+            it('should still check the exception type', function() {
+                $this->matcher->setExpectedMessage("hello world");
+                $result = $this->matcher->match(function() {
+                    throw new RuntimeException('hello world');
+                });
+                expect($result->isMatch())->to->equal(false);
+            });
+
             context('and matcher is inverted', function() {
                 it('should return true result if exception messages are different', function() {
                     $this->matcher->setExpectedMessage('goodbye');

--- a/src/Matcher/ExceptionMatcher.php
+++ b/src/Matcher/ExceptionMatcher.php
@@ -177,20 +177,37 @@ class ExceptionMatcher extends AbstractMatcher
     }
 
     /**
-     * Override match to set actual and expect match values to message
-     * values.
+     * Executes the callable and matches the exception type and exception message.
      *
      * @param $actual
      * @return Match
      */
     public function match($actual)
     {
-        $match = parent::match($actual);
-        if ($this->expectedMessage) {
-            $match->setActual($this->message);
-            $match->setExpected($this->expectedMessage);
+        $this->validateCallable($actual);
+        try {
+            call_user_func_array($actual, $this->arguments);
+            $isMatch = false;
+        } catch (\Exception $e) {
+            $isMatch = $e instanceof $this->expected;
+            $message = $e->getMessage();
+            $this->setMessage($message);
         }
-        return $match;
+        if ($isMatch && $this->expectedMessage) {
+            $isMatch = $message == $this->expectedMessage;
+            $expected = $this->expectedMessage;
+            $actual = $message;
+        } else {
+            $expected = $this->expected;
+        }
+
+        $isNegated = $this->isNegated();
+
+        if ($isNegated) {
+            $isMatch = !$isMatch;
+        }
+
+        return new Match($isMatch, $expected, $actual, $isNegated);
     }
 
     /**
@@ -201,21 +218,6 @@ class ExceptionMatcher extends AbstractMatcher
      */
     protected function doMatch($actual)
     {
-        $this->validateCallable($actual);
-        try {
-            call_user_func_array($actual, $this->arguments);
-            return false;
-        } catch (\Exception $e) {
-            $message = $e->getMessage();
-            if ($this->expectedMessage) {
-                $this->setMessage($message);
-                return $this->expectedMessage == $message;
-            }
-            if (!$e instanceof $this->expected) {
-                return false;
-            }
-        }
-        return true;
     }
 
     /**


### PR DESCRIPTION
This PR addresses #20. In short, Leo's `ExceptionMatcher` was bypassing the type check when an expected exception message was specified.

FYI, I have a few PRs to come, and a couple are predicated on this one.