### PR TITLE
Simplified assertion exception stack trace trimming.

### DIFF
--- a/specs/responder/exception/assertion-exception.spec.php
+++ b/specs/responder/exception/assertion-exception.spec.php
@@ -4,7 +4,7 @@ use Peridot\Leo\Responder\Exception\AssertionException;
 
 describe('AssertionException', function() {
     describe('::trim()', function() {
-        xit('handles traces without a Leo call', function() {
+        it('handles traces without a Leo call', function() {
             $exception = new Exception();
             AssertionException::trim($exception);
             expect(count($exception->getTrace()))->to->equal(0);

--- a/src/Responder/Exception/AssertionException.php
+++ b/src/Responder/Exception/AssertionException.php
@@ -60,32 +60,19 @@ final class AssertionException extends Exception
     {
         $prefix = 'Peridot\\Leo\\';
 
-        $index = null;
-        $broke = false;
+        for ($i = count($trace) - 1; $i >= 0; --$i) {
+            $entry = $trace[$i];
 
-        foreach ($trace as $index => $call) {
-            if (isset($call['class'])) {
-                if (0 !== strpos($call['class'], $prefix)) {
-                    $broke = true;
-
-                    break;
+            if (isset($entry['class'])) {
+                if (0 === strpos($entry['class'], $prefix)) {
+                    return $entry;
                 }
-            } elseif (0 !== strpos($call['function'], $prefix)) {
-                $broke = true;
-
-                break;
+            } elseif (0 === strpos($entry['function'], $prefix)) {
+                return $entry;
             }
         }
 
-        if (null === $index) {
-            return;
-        }
-
-        if (!$broke) {
-            ++$index;
-        }
-
-        return $trace[$index - 1];
+        return null;
     }
 
     /**


### PR DESCRIPTION
This PR simplifies the assertion stack trace trimming I implemented previously, which I copied from [Phony](https://github.com/eloquent/phony).

I found an edge-case bug in the code to do with manually constructing the exception from outside the library's namespace. It probably isn't affecting anyone in the real world, but I ended up refactoring the code to be much simpler, so I thought I'd update the Leo code also.

In addition, I fixed one of the current warnings generated by the test suite. There are still a couple of others to do with `ArrayAccess` support in `InclusionMatcher`, so the build will fail here, and that's expected. I'll submit another PR to fix those up shortly.