### PR TITLE
Support for traversables in InclusionMatcher

### DIFF
--- a/specs/matcher/inclusion-matcher.spec.php
+++ b/specs/matcher/inclusion-matcher.spec.php
@@ -17,7 +17,7 @@ describe('InclusionMatcher', function() {
         expect($match->isMatch())->to->equal(true);
     });
 
-    xit('should return true if value is in an instance of ArrayAccess', function() {
+    it('should return true if value is in an instance of Traversable', function() {
         $match = $this->matcher->match(new ArrayObject(['A', 'B', 'C']));
         expect($match->isMatch())->to->equal(true);
     });
@@ -38,9 +38,9 @@ describe('InclusionMatcher', function() {
         expect($match->isMatch())->to->equal(false);
     });
 
-    xit('should return true if value is not in an instance of ArrayAccess', function() {
+    it('should return false if value is not in an instance of Traversable', function() {
         $match = $this->matcher->match(new ArrayObject(['B', 'C', 'D']));
-        expect($match->isMatch())->to->equal(true);
+        expect($match->isMatch())->to->equal(false);
     });
 
     it('should return false if value is not in string', function() {

--- a/src/Matcher/InclusionMatcher.php
+++ b/src/Matcher/InclusionMatcher.php
@@ -2,10 +2,10 @@
 
 namespace Peridot\Leo\Matcher;
 
-use ArrayAccess;
 use InvalidArgumentException;
 use Peridot\Leo\Matcher\Template\ArrayTemplate;
 use Peridot\Leo\Matcher\Template\TemplateInterface;
+use Traversable;
 
 /**
  * InclusionMatcher determines if an array or string includes the expected value.
@@ -23,8 +23,21 @@ class InclusionMatcher extends AbstractMatcher
      */
     protected function doMatch($actual)
     {
-        //we will support ArrayAccess for now, even though array_search throws a warning about it
-        if (is_array($actual) or $actual instanceof ArrayAccess) {
+        if ($actual instanceof Traversable) {
+            $isMatch = false;
+
+            foreach ($actual as $value) {
+                if ($value === $this->expected) {
+                    $isMatch = true;
+
+                    break;
+                }
+            }
+
+            return $isMatch;
+        }
+
+        if (is_array($actual)) {
             return array_search($this->expected, $actual, true) !== false;
         }
 


### PR DESCRIPTION
This PR introduces support for objects that implement `Traversable` in the `InclusionMatcher`.

Previously, the inclusion matcher attempted to support objects that implement `ArrayAccess`, which doesn't actually make sense, and never worked (the test was expecting the wrong result).

I've predicated this PR on top of #22, please merge that one before this if it looks okay. The reason for this is that hopefully together, these two PRs will fix the Travis build status issues plaguing other PRs I'm trying to submit.