### PR TITLE
Fixed simultaneous assertion of exception type and message.

### DIFF
--- a/specs/interfaces/assert.spec.php
+++ b/specs/interfaces/assert.spec.php
@@ -79,7 +79,7 @@ describe('assert', function() {
             $this->assert->throws(function() {
                 $this->assert->doesNotThrow(function() {
                     throw new Exception('failure');
-                }, 'RuntimeException', 'failure');
+                }, 'Exception', 'failure');
             }, 'Exception');
         });
 
@@ -87,7 +87,7 @@ describe('assert', function() {
             $this->assert->throws(function() {
                 $this->assert->doesNotThrow(function() {
                     throw new Exception('failure');
-                }, 'RuntimeException', 'failure', 'oooooops');
+                }, 'Exception', 'failure', 'oooooops');
             }, 'Exception', 'oooooops');
         });
     });

--- a/specs/matcher/exception-matcher.spec.php
+++ b/specs/matcher/exception-matcher.spec.php
@@ -68,6 +68,14 @@ describe('ExceptionMatcher', function() {
                 expect($result->isMatch())->to->equal(false);
             });
 
+            it('should still check the exception type', function() {
+                $this->matcher->setExpectedMessage("hello world");
+                $result = $this->matcher->match(function() {
+                    throw new RuntimeException('hello world');
+                });
+                expect($result->isMatch())->to->equal(false);
+            });
+
             context('and matcher is inverted', function() {
                 it('should return true result if exception messages are different', function() {
                     $this->matcher->setExpectedMessage('goodbye');


### PR DESCRIPTION
Re-do of #21, predicated on #22 and #23 .

This PR addresses #20. In short, Leo's `ExceptionMatcher` was bypassing the type check when an expected exception message was specified.

FYI, I have a few PRs to come, and a couple are predicated on this one.