### PR TITLE
Prototype diff formatting for discussion

### DIFF
--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -98,6 +98,7 @@ class Formatter implements FormatterInterface
         $vars = [
             'expected' => $this->match->getExpected(),
             'actual' => $this->match->getActual(),
+            'diff' => is_callable($this->match->differ)?call_user_func($this->match->differ, $this->match->getActual(), $this->match->getExpected()):""
         ];
 
         if ($tplVars = $template->getTemplateVars()) {

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -95,10 +95,11 @@ class Formatter implements FormatterInterface
      */
     protected function getTemplateVars(TemplateInterface $template)
     {
+        $differExists = (property_exists($this->match, "differ") && is_callable($this->match->differ));
         $vars = [
             'expected' => $this->match->getExpected(),
             'actual' => $this->match->getActual(),
-            'diff' => is_callable($this->match->differ)?call_user_func($this->match->differ, $this->match->getActual(), $this->match->getExpected()):""
+            'diff' => $differExists?call_user_func($this->match->differ, $this->match->getActual(), $this->match->getExpected()):"",
         ];
 
         if ($tplVars = $template->getTemplateVars()) {

--- a/src/Matcher/AbstractMatcher.php
+++ b/src/Matcher/AbstractMatcher.php
@@ -31,8 +31,13 @@ abstract class AbstractMatcher implements MatcherInterface
     {
         $isMatch = $this->doMatch($actual);
         $isNegated = $this->isNegated();
+        $fulfillsExpectation = ($isMatch xor $isNegated);
 
-        return new Match($isMatch xor $isNegated, $this->expected, $actual, $isNegated);
+        $match = new Match($fulfillsExpectation, $this->expected, $actual, $isNegated);
+        if ((!$fulfillsExpectation) && method_exists($this, "differ")) {
+            $match->differ = [$this, "differ"];
+        }
+        return $match;
     }
 
     /**

--- a/src/Matcher/SameMatcher.php
+++ b/src/Matcher/SameMatcher.php
@@ -11,6 +11,10 @@ use Peridot\Leo\Matcher\Template\TemplateInterface;
  */
 class SameMatcher extends AbstractMatcher
 {
+    public function differ($actual, $expected) {
+        return "THE CALCULATED DIFF";
+    }
+
     /**
      * Match if the actual value is identical to the expected value using an ===
      * comparison.
@@ -31,7 +35,7 @@ class SameMatcher extends AbstractMatcher
     public function getDefaultTemplate()
     {
         return new ArrayTemplate([
-            'default' => 'Expected {{actual}} to be identical to {{expected}}',
+            'default' => 'Expected {{actual}} to be identical to {{expected}}. Difference: {{diff}}',
             'negated' => 'Expected {{actual}} not to be identical to {{expected}}',
         ]);
     }


### PR DESCRIPTION
This pull request contains a unfinished prototype for discussing an implementation of a feature.

It would be good to be able to see not only that actual and expected results are different,
but also one would like to see in which way they differ.

I couldnt find a way to extend leo for diffing in plugin-kind of way. So I started prototyping.

This commit prototypes a possible implementation with the following properties
* Because the relevant different depends on the type of matcher,
  each matcher supporting diffs (see SameMatcher) gets a $differ method to be called by the formatter
* also the matcher adds a "diff" to the format template vars
* on match, the abstract matcher adds the differ to match the result iff the result is unexpected
* Formatter reads and prints the $diff member from the matcher
* diffing is actually not implemented, that probably should be plugged in using a thirdparty lib

This indicates
* leo probably should not force diff calculation on users
* there should be a kind of extension point to add a differ implementation

So this bears the questions:
* is there a way already to hook in diffing?
* is there a better place than Matcher/Match/Formatter ?
** should diff calculation happen when matching or when formatting
* where/how would I register a Differ?
* should the Differ be added as mix-in on the Matchers?
