### PR TITLE
Modify the name of the Match class as Match is now a reserved word in PHP8

### DIFF
--- a/specs/formatter/formatter.spec.php
+++ b/specs/formatter/formatter.spec.php
@@ -1,7 +1,7 @@
 <?php
 
 use Peridot\Leo\Formatter\Formatter;
-use Peridot\Leo\Matcher\Match;
+use Peridot\Leo\Matcher\MatchClass;
 use Peridot\Leo\Matcher\Template\ArrayTemplate;
 
 describe('Formatter', function () {
@@ -11,7 +11,7 @@ describe('Formatter', function () {
 
     describe('match accessors', function () {
         it('should allow access to match', function () {
-            $match = new Match(false, 4, 3, false);
+            $match = new MatchClass(false, 4, 3, false);
             $this->formatter->setMatch($match);
             expect($this->formatter->getMatch())->to->equal($match);
         });
@@ -55,13 +55,13 @@ describe('Formatter', function () {
         });
 
         it('should return a default message based on a template', function () {
-            $match = new Match(false, 4, 3, false);
+            $match = new MatchClass(false, 4, 3, false);
             $message = $this->formatter->setMatch($match)->getMessage($this->template);
             expect($message)->to->equal('Expected 4, got 3');
         });
 
         it('should return a negated message based on a template', function () {
-            $match = new Match(false, 4, 4, true);
+            $match = new MatchClass(false, 4, 4, true);
             $message = $this->formatter->setMatch($match)->getMessage($this->template);
             expect($message)->to->equal('Expected 4 not to be 4');
         });

--- a/specs/matcher/match.spec.php
+++ b/specs/matcher/match.spec.php
@@ -1,14 +1,14 @@
 <?php
 
-use Peridot\Leo\Matcher\Match;
+use Peridot\Leo\Matcher\MatchClass;
 
-describe('Match', function () {
+describe('MatchClass', function () {
     beforeEach(function () {
         $this->isMatch = false;
         $this->expected = 'expected';
         $this->actual = 'actual';
         $this->isNegated = false;
-        $this->subject = new Match($this->isMatch, $this->expected, $this->actual, $this->isNegated);
+        $this->subject = new MatchClass($this->isMatch, $this->expected, $this->actual, $this->isNegated);
     });
 
     it('should retain the data passed to the constructor', function () {

--- a/specs/responder/responder.spec.php
+++ b/specs/responder/responder.spec.php
@@ -1,6 +1,6 @@
 <?php
 
-use Peridot\Leo\Matcher\Match;
+use Peridot\Leo\Matcher\MatchClass;
 use Peridot\Leo\Matcher\Template\ArrayTemplate;
 use Peridot\Leo\Responder\Exception\AssertionException;
 use Peridot\Leo\Responder\ExceptionResponder;
@@ -15,7 +15,7 @@ describe('ExceptionResponder', function () {
     describe('->respond()', function () {
         beforeEach(function () {
             $this->formatter->getMessage(Argument::any())->willReturn('FAIL');
-            $this->match = new Match(false, 4, 3, false);
+            $this->match = new MatchClass(false, 4, 3, false);
             $this->template = new ArrayTemplate([
                 'default' => 'Default',
                 'negated' => 'Negated',
@@ -55,7 +55,7 @@ describe('ExceptionResponder', function () {
         });
 
         it('should do nothing for a true match', function () {
-            $match = new Match(true, 3, 3, false);
+            $match = new MatchClass(true, 3, 3, false);
             $template = new ArrayTemplate(['default' => '', 'negated' => '']);
             $this->formatter->getMessage(Argument::any())->shouldNotBeCalled();
             $this->formatter->setMatch($match)->shouldNotBeCalled();

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -2,7 +2,7 @@
 
 namespace Peridot\Leo\Formatter;
 
-use Peridot\Leo\Matcher\Match;
+use Peridot\Leo\Matcher\MatchClass;
 use Peridot\Leo\Matcher\Template\TemplateInterface;
 
 /**
@@ -13,7 +13,7 @@ use Peridot\Leo\Matcher\Template\TemplateInterface;
 class Formatter implements FormatterInterface
 {
     /**
-     * @var Match
+     * @var MatchClass
      */
     protected $match;
 
@@ -24,7 +24,7 @@ class Formatter implements FormatterInterface
     /**
      * {@inheritdoc}
      *
-     * @return Match
+     * @return MatchClass
      */
     public function getMatch()
     {
@@ -34,10 +34,10 @@ class Formatter implements FormatterInterface
     /**
      * {@inheritdoc}
      *
-     * @param  Match $match
+     * @param  MatchClass $match
      * @return $this
      */
-    public function setMatch(Match $match)
+    public function setMatch(MatchClass $match)
     {
         $this->match = $match;
 

--- a/src/Formatter/FormatterInterface.php
+++ b/src/Formatter/FormatterInterface.php
@@ -2,7 +2,7 @@
 
 namespace Peridot\Leo\Formatter;
 
-use Peridot\Leo\Matcher\Match;
+use Peridot\Leo\Matcher\MatchClass;
 use Peridot\Leo\Matcher\Template\TemplateInterface;
 
 /**
@@ -15,16 +15,16 @@ interface FormatterInterface
     /**
      * Return the match being formatted.
      *
-     * @return Match
+     * @return MatchClass
      */
     public function getMatch();
 
     /**
      * Set the match to format results for.
      *
-     * @param Match $match
+     * @param MatchClass $match
      */
-    public function setMatch(Match $match);
+    public function setMatch(MatchClass $match);
 
     /**
      * Applies the match to the given TemplateInterface

--- a/src/Matcher/AbstractMatcher.php
+++ b/src/Matcher/AbstractMatcher.php
@@ -25,14 +25,14 @@ abstract class AbstractMatcher implements MatcherInterface
      * {@inheritdoc}
      *
      * @param  mixed $actual
-     * @return Match
+     * @return MatchClass
      */
     public function match($actual = '')
     {
         $isMatch = $this->doMatch($actual);
         $isNegated = $this->isNegated();
 
-        return new Match($isMatch xor $isNegated, $this->expected, $actual, $isNegated);
+        return new MatchClass($isMatch xor $isNegated, $this->expected, $actual, $isNegated);
     }
 
     /**
@@ -51,7 +51,7 @@ abstract class AbstractMatcher implements MatcherInterface
 
     /**
      * The actual matching algorithm for the matcher. This is called by ->match()
-     * to create a Match result.
+     * to create a MatchClass result.
      *
      * @param  mixed $actual
      * @return bool

--- a/src/Matcher/ExceptionMatcher.php
+++ b/src/Matcher/ExceptionMatcher.php
@@ -170,7 +170,7 @@ class ExceptionMatcher implements MatcherInterface
      * Executes the callable and matches the exception type and exception message.
      *
      * @param $actual
-     * @return Match
+     * @return MatchClass
      */
     public function match($actual)
     {
@@ -221,7 +221,7 @@ class ExceptionMatcher implements MatcherInterface
 
         $isNegated = $this->isNegated();
 
-        return new Match($isNegated, $this->expectedMessage, $message, $isNegated);
+        return new MatchClass($isNegated, $this->expectedMessage, $message, $isNegated);
     }
 
     private function matchType($actual, $exception)
@@ -229,7 +229,7 @@ class ExceptionMatcher implements MatcherInterface
         $isMatch = $exception instanceof $this->expected;
         $isNegated = $this->isNegated();
 
-        return new Match($isMatch xor $isNegated, $this->expected, $actual, $isNegated);
+        return new MatchClass($isMatch xor $isNegated, $this->expected, $actual, $isNegated);
     }
 
     /**

--- a/src/Matcher/MatchClass.php
+++ b/src/Matcher/MatchClass.php
@@ -3,11 +3,11 @@
 namespace Peridot\Leo\Matcher;
 
 /**
- * A Match is the result of MatcherInterface::match($actual).
+ * A MatchClass is the result of MatcherInterface::match($actual).
  *
  * @package Peridot\Leo\Matcher
  */
-class Match
+class MatchClass
 {
     /**
      * @var bool

--- a/src/Matcher/MatcherInterface.php
+++ b/src/Matcher/MatcherInterface.php
@@ -34,7 +34,7 @@ interface MatcherInterface
      * Perform a match against an actual value.
      *
      * @param  mixed $actual
-     * @return Match
+     * @return MatchClass
      */
     public function match($actual);
 

--- a/src/Matcher/PredicateMatcher.php
+++ b/src/Matcher/PredicateMatcher.php
@@ -7,7 +7,7 @@ use Peridot\Leo\Matcher\Template\TemplateInterface;
 
 /**
  * PredicateMatcher executes a function with the actual value. The PredicateMatcher returns
- * the result of that function call as a Match result.
+ * the result of that function call as a MatchClass result.
  *
  * @package Peridot\Leo\Matcher
  */

--- a/src/Matcher/TypeMatcher.php
+++ b/src/Matcher/TypeMatcher.php
@@ -21,7 +21,7 @@ class TypeMatcher extends AbstractMatcher
      * {@inheritdoc}
      *
      * @param $actual
-     * @return Match
+     * @return MatchClass
      */
     public function match($actual = '')
     {

--- a/src/Responder/ExceptionResponder.php
+++ b/src/Responder/ExceptionResponder.php
@@ -4,7 +4,7 @@ namespace Peridot\Leo\Responder;
 
 use Exception;
 use Peridot\Leo\Formatter\FormatterInterface;
-use Peridot\Leo\Matcher\Match;
+use Peridot\Leo\Matcher\MatchClass;
 use Peridot\Leo\Matcher\Template\TemplateInterface;
 use Peridot\Leo\Responder\Exception\AssertionException;
 
@@ -34,13 +34,13 @@ class ExceptionResponder implements ResponderInterface
      *
      * Throws an exception containing the formatted message.
      *
-     * @param  Match             $match
+     * @param  MatchClass             $match
      * @param  TemplateInterface $template
      * @param  string            $message
      * @return void
      * @throws Exception
      */
-    public function respond(Match $match, TemplateInterface $template, $message = '')
+    public function respond(MatchClass $match, TemplateInterface $template, $message = '')
     {
         if ($match->isMatch()) {
             return;

--- a/src/Responder/ResponderInterface.php
+++ b/src/Responder/ResponderInterface.php
@@ -2,7 +2,7 @@
 
 namespace Peridot\Leo\Responder;
 
-use Peridot\Leo\Matcher\Match;
+use Peridot\Leo\Matcher\MatchClass;
 use Peridot\Leo\Matcher\Template\TemplateInterface;
 
 /**
@@ -14,12 +14,12 @@ use Peridot\Leo\Matcher\Template\TemplateInterface;
 interface ResponderInterface
 {
     /**
-     * Respond to a Match given a TemplateInterface to format the message.
+     * Respond to a MatchClass given a TemplateInterface to format the message.
      *
-     * @param  Match             $match
+     * @param  MatchClass             $match
      * @param  TemplateInterface $template
      * @param  string            $message  a user provided messaged
      * @return mixed
      */
-    public function respond(Match $match, TemplateInterface $template, $message);
+    public function respond(MatchClass $match, TemplateInterface $template, $message);
 }


### PR DESCRIPTION
This has been renamed to MatchClass (could not think of any better alternative)